### PR TITLE
Update GitHub Pages URL

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -18,8 +18,8 @@ keywords: jekyll, jekyll-theme, academic-website, portfolio-website # add your o
 lang: en # the language of your site (for example: en, fr, cn, ru, etc.)
 icon: ⚛️ # the emoji used as the favicon (alternatively, provide image name in /assets/img/)
 
-url: https://alshedivat.github.io # the base hostname & protocol for your site
-baseurl: /al-folio # the subpath of your site, e.g. /blog/. Leave blank for root
+url: https://laurence.github.io # the base hostname & protocol for your site
+baseurl: "" # the subpath of your site, e.g. /blog/. Leave blank for root
 last_updated: false # set to true if you want to display last updated in the footer
 impressum_path: # set to path to include impressum link in the footer, use the same path as permalink in a page, helps to conform with EU GDPR
 back_to_top: true # set to false to disable the back to top button


### PR DESCRIPTION
## Summary
- use `https://laurence.github.io` as the site URL
- clear `baseurl` for site root

## Testing
- `bundle install`
- `bundle exec jekyll build` *(fails: 403 Forbidden while fetching external posts)*

------
https://chatgpt.com/codex/tasks/task_e_683fdb1e2eb88329be63dc0a05b2307f